### PR TITLE
Feature/Fix Navigation Bug

### DIFF
--- a/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
+++ b/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.apeun.gidaechi.main
 
+import android.util.Log
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -8,6 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -17,6 +20,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.apeun.gidaechi.chat.navigation.CHAT_ROUTE
 import com.apeun.gidaechi.chat.navigation.chatScreen
@@ -39,11 +43,34 @@ private const val NAVIGATION_ANIM = 400
 
 @Composable
 internal fun MainScreen(navHostController: NavHostController = rememberNavController()) {
-    var selectItemState: BottomNavigationItemType by remember { mutableStateOf(BottomNavigationItemType.Home) }
+    val backstackEntry by navHostController.currentBackStackEntryAsState()
+    val selectItemState: BottomNavigationItemType by remember {
+        derivedStateOf {
+            when(backstackEntry?.destination?.route) {
+                HOME_ROUTE -> BottomNavigationItemType.Home
+                CHAT_ROUTE -> BottomNavigationItemType.Chat
+                ROOM_ROUTE -> BottomNavigationItemType.Group
+                NOTIFICATION_ROUTE -> BottomNavigationItemType.Notification
+                PROFILE_ROUTE -> BottomNavigationItemType.Profile
+                else -> BottomNavigationItemType.Home
+            }
+        }
+    }
     var navigationVisible by remember { mutableStateOf(true) }
-
     val onNavigationVisibleChange: (Boolean) -> Unit = {
         navigationVisible = it
+    }
+
+    LaunchedEffect(key1 = backstackEntry?.destination?.route) {
+        val test = when(backstackEntry?.destination?.route) {
+            HOME_ROUTE -> BottomNavigationItemType.Home
+            CHAT_ROUTE -> BottomNavigationItemType.Chat
+            ROOM_ROUTE -> BottomNavigationItemType.Group
+            NOTIFICATION_ROUTE -> BottomNavigationItemType.Notification
+            PROFILE_ROUTE -> BottomNavigationItemType.Profile
+            else -> BottomNavigationItemType.Home
+        }
+        Log.d("TAG", "MainScreen: ${test} ${backstackEntry?.destination?.route} ${backstackEntry?.destination?.id}")
     }
 
     Scaffold(
@@ -51,7 +78,6 @@ internal fun MainScreen(navHostController: NavHostController = rememberNavContro
         bottomBar = {
             if (navigationVisible) {
                 SeugiBottomNavigation(selected = selectItemState) {
-                    selectItemState = it
                     navHostController.navigate(
                         when (it) {
                             is BottomNavigationItemType.Home -> HOME_ROUTE

--- a/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
+++ b/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
@@ -85,7 +85,7 @@ internal fun MainScreen(navHostController: NavHostController = rememberNavContro
                             is BottomNavigationItemType.Group -> ROOM_ROUTE
                             is BottomNavigationItemType.Notification -> NOTIFICATION_ROUTE
                             is BottomNavigationItemType.Profile -> PROFILE_ROUTE
-                            else -> "route"
+                            else -> HOME_ROUTE
                         },
                     ) {
                         popUpTo(navHostController.graph.findStartDestination().id) {
@@ -109,10 +109,6 @@ internal fun MainScreen(navHostController: NavHostController = rememberNavContro
             popEnterTransition = { fadeIn(animationSpec = tween(NAVIGATION_ANIM)) },
             popExitTransition = { fadeOut(animationSpec = tween(NAVIGATION_ANIM)) },
         ) {
-            // TODO("DELETE DUMMY ROUTE")
-            composable("route") {
-                Text(text = "hi")
-            }
 
             homeScreen()
 

--- a/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
+++ b/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
@@ -61,18 +61,6 @@ internal fun MainScreen(navHostController: NavHostController = rememberNavContro
         navigationVisible = it
     }
 
-    LaunchedEffect(key1 = backstackEntry?.destination?.route) {
-        val test = when(backstackEntry?.destination?.route) {
-            HOME_ROUTE -> BottomNavigationItemType.Home
-            CHAT_ROUTE -> BottomNavigationItemType.Chat
-            ROOM_ROUTE -> BottomNavigationItemType.Group
-            NOTIFICATION_ROUTE -> BottomNavigationItemType.Notification
-            PROFILE_ROUTE -> BottomNavigationItemType.Profile
-            else -> BottomNavigationItemType.Home
-        }
-        Log.d("TAG", "MainScreen: ${test} ${backstackEntry?.destination?.route} ${backstackEntry?.destination?.id}")
-    }
-
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         bottomBar = {

--- a/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
+++ b/feature-main/main/src/main/java/com/apeun/gidaechi/main/MainScreen.kt
@@ -1,15 +1,12 @@
 package com.apeun.gidaechi.main
 
-import android.util.Log
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.apeun.gidaechi.chat.navigation.CHAT_ROUTE
@@ -46,7 +42,7 @@ internal fun MainScreen(navHostController: NavHostController = rememberNavContro
     val backstackEntry by navHostController.currentBackStackEntryAsState()
     val selectItemState: BottomNavigationItemType by remember {
         derivedStateOf {
-            when(backstackEntry?.destination?.route) {
+            when (backstackEntry?.destination?.route) {
                 HOME_ROUTE -> BottomNavigationItemType.Home
                 CHAT_ROUTE -> BottomNavigationItemType.Chat
                 ROOM_ROUTE -> BottomNavigationItemType.Group
@@ -97,7 +93,6 @@ internal fun MainScreen(navHostController: NavHostController = rememberNavContro
             popEnterTransition = { fadeIn(animationSpec = tween(NAVIGATION_ANIM)) },
             popExitTransition = { fadeOut(animationSpec = tween(NAVIGATION_ANIM)) },
         ) {
-
             homeScreen()
 
             chatScreen(


### PR DESCRIPTION
## 개요 (필수)

- 뒤로가기를 누를 경우, 하단의 바텀네비게이션 아이템이 제대로 표기되지 않던 점을, BackStackEntry를 통해 현재 화면의 Route를 통해 파악하도록 구현하였습니다 

## 이슈 번호

- close #131