### PR TITLE
Fix/Chat Name Height Maximum

### DIFF
--- a/designsystem/src/main/java/com/seugi/designsystem/component/chat/ChatList.kt
+++ b/designsystem/src/main/java/com/seugi/designsystem/component/chat/ChatList.kt
@@ -67,6 +67,7 @@ fun SeugiChatList(
                             text = userName,
                             style = SeugiTheme.typography.subtitle2,
                             color = SeugiTheme.colors.black,
+                            maxLines = 1,
                         )
                         if (memberCount != null) {
                             Spacer(modifier = Modifier.width(4.dp))


### PR DESCRIPTION
## 개요 (필수)

- 채팅방 이름이 길어도 짜르지 않고 모두 표시하는 버그를 수정하였습니다.

## 이슈 번호

- close #314 