### PR TITLE
Feature/Add Room Create Navigate Pop Back Stack on Room Create

### DIFF
--- a/feature-main/main/src/main/java/com/seugi/main/MainScreen.kt
+++ b/feature-main/main/src/main/java/com/seugi/main/MainScreen.kt
@@ -216,6 +216,7 @@ internal fun MainScreen(
                     navHostController.popBackStack()
                 },
                 navigateToChatDetail = { chatId, workspaceId, isPersonal ->
+                    navHostController.popBackStack()
                     navHostController.navigateToChatDetail(
                         chatRoomId = chatId,
                         workspaceId = workspaceId,


### PR DESCRIPTION
## 개요 (필수)

- 방 생성 후, 뒤로가기를 눌러도 다시 생성화면으로 가던 것을 채팅방 목록으로 가도록 하였습니다.

## 이슈 번호

- close #366 