### PR TITLE
Refactor/Socket Stability

### DIFF
--- a/data/message/src/main/java/com/seugi/data/message/MessageRepository.kt
+++ b/data/message/src/main/java/com/seugi/data/message/MessageRepository.kt
@@ -3,8 +3,10 @@ package com.seugi.data.message
 import com.seugi.common.model.Result
 import com.seugi.data.message.model.MessageLoadModel
 import com.seugi.data.message.model.MessageRoomEvent
+import com.seugi.data.message.model.MessageStompErrorModel
 import com.seugi.data.message.model.MessageType
 import com.seugi.data.message.model.stomp.MessageStompLifecycleModel
+import com.seugi.network.message.response.stomp.MessageStompErrorResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDateTime
 
@@ -13,6 +15,10 @@ interface MessageRepository {
     suspend fun sendMessage(chatRoomId: String, message: String, messageUUID: String, type: MessageType, mention: List<Long>): Result<Boolean>
 
     suspend fun subscribeRoom(chatRoomId: String, userId: Long): Flow<Result<MessageRoomEvent>>
+
+    suspend fun subscribeError(): Flow<Result<MessageStompErrorModel>>
+
+    suspend fun closeSocket(): Boolean
 
     suspend fun reSubscribeRoom(chatRoomId: String, userId: Long): Flow<Result<MessageRoomEvent>>
 

--- a/data/message/src/main/java/com/seugi/data/message/MessageRepository.kt
+++ b/data/message/src/main/java/com/seugi/data/message/MessageRepository.kt
@@ -6,7 +6,6 @@ import com.seugi.data.message.model.MessageRoomEvent
 import com.seugi.data.message.model.MessageStompErrorModel
 import com.seugi.data.message.model.MessageType
 import com.seugi.data.message.model.stomp.MessageStompLifecycleModel
-import com.seugi.network.message.response.stomp.MessageStompErrorResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDateTime
 

--- a/data/message/src/main/java/com/seugi/data/message/mapper/MessageStompErrorMapper.kt
+++ b/data/message/src/main/java/com/seugi/data/message/mapper/MessageStompErrorMapper.kt
@@ -3,10 +3,9 @@ package com.seugi.data.message.mapper
 import com.seugi.data.message.model.MessageStompErrorModel
 import com.seugi.network.message.response.stomp.MessageStompErrorResponse
 
-internal fun MessageStompErrorResponse.toModel() =
-    MessageStompErrorModel(
-        status = status,
-        success = success,
-        state = state,
-        message = message
-    )
+internal fun MessageStompErrorResponse.toModel() = MessageStompErrorModel(
+    status = status,
+    success = success,
+    state = state,
+    message = message,
+)

--- a/data/message/src/main/java/com/seugi/data/message/mapper/MessageStompErrorMapper.kt
+++ b/data/message/src/main/java/com/seugi/data/message/mapper/MessageStompErrorMapper.kt
@@ -1,0 +1,12 @@
+package com.seugi.data.message.mapper
+
+import com.seugi.data.message.model.MessageStompErrorModel
+import com.seugi.network.message.response.stomp.MessageStompErrorResponse
+
+internal fun MessageStompErrorResponse.toModel() =
+    MessageStompErrorModel(
+        status = status,
+        success = success,
+        state = state,
+        message = message
+    )

--- a/data/message/src/main/java/com/seugi/data/message/model/MessageStompErrorModel.kt
+++ b/data/message/src/main/java/com/seugi/data/message/model/MessageStompErrorModel.kt
@@ -4,5 +4,5 @@ data class MessageStompErrorModel(
     val status: Int,
     val success: Boolean,
     val state: String,
-    val message: String
+    val message: String,
 )

--- a/data/message/src/main/java/com/seugi/data/message/model/MessageStompErrorModel.kt
+++ b/data/message/src/main/java/com/seugi/data/message/model/MessageStompErrorModel.kt
@@ -1,0 +1,8 @@
+package com.seugi.data.message.model
+
+data class MessageStompErrorModel(
+    val status: Int,
+    val success: Boolean,
+    val state: String,
+    val message: String
+)

--- a/data/message/src/main/java/com/seugi/data/message/repository/MessageRepositoryImpl.kt
+++ b/data/message/src/main/java/com/seugi/data/message/repository/MessageRepositoryImpl.kt
@@ -60,7 +60,8 @@ class MessageRepositoryImpl @Inject constructor(
         }
         return datasource.subscribeRoom(chatRoomId)
             .flowOn(dispatcher)
-            .map {/**/
+            .map {
+                /**/
                 it.toEventModel(userId)
             }
             .asResult()
@@ -70,7 +71,7 @@ class MessageRepositoryImpl @Inject constructor(
         if (!datasource.getIsConnect()) {
             val token = tokenDao.getToken()
             datasource.connectStompSocket(
-                token?.token ?: ""
+                token?.token ?: "",
             )
         }
         return datasource.subscribeError()

--- a/data/message/src/main/java/com/seugi/data/message/repository/MessageRepositoryImpl.kt
+++ b/data/message/src/main/java/com/seugi/data/message/repository/MessageRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.seugi.common.model.Result
 import com.seugi.common.model.asResult
 import com.seugi.common.utiles.DispatcherType
 import com.seugi.common.utiles.SeugiDispatcher
-import com.seugi.data.core.mapper.toModel
 import com.seugi.data.core.mapper.toModels
 import com.seugi.data.core.model.TimetableModel
 import com.seugi.data.message.MessageRepository
@@ -16,6 +15,7 @@ import com.seugi.data.message.model.MessageBotRawKeyword
 import com.seugi.data.message.model.MessageBotRawKeywordInData
 import com.seugi.data.message.model.MessageLoadModel
 import com.seugi.data.message.model.MessageRoomEvent
+import com.seugi.data.message.model.MessageStompErrorModel
 import com.seugi.data.message.model.MessageType
 import com.seugi.data.message.model.stomp.MessageStompLifecycleModel
 import com.seugi.local.room.dao.TokenDao
@@ -54,27 +54,47 @@ class MessageRepositoryImpl @Inject constructor(
     override suspend fun subscribeRoom(chatRoomId: String, userId: Long): Flow<Result<MessageRoomEvent>> {
         if (!datasource.getIsConnect()) {
             val token = tokenDao.getToken()
-            datasource.connectStomp(
+            datasource.connectStompSocket(
                 token?.token ?: "",
             )
         }
         return datasource.subscribeRoom(chatRoomId)
             .flowOn(dispatcher)
-            .map {
+            .map {/**/
                 it.toEventModel(userId)
             }
             .asResult()
     }
 
+    override suspend fun subscribeError(): Flow<Result<MessageStompErrorModel>> {
+        if (!datasource.getIsConnect()) {
+            val token = tokenDao.getToken()
+            datasource.connectStompSocket(
+                token?.token ?: ""
+            )
+        }
+        return datasource.subscribeError()
+            .flowOn(dispatcher)
+            .map {
+                it.toModel()
+            }
+            .asResult()
+    }
+
+    override suspend fun closeSocket(): Boolean {
+        datasource.closeStompSocket()
+        return true
+    }
+
     override suspend fun reSubscribeRoom(chatRoomId: String, userId: Long): Flow<Result<MessageRoomEvent>> {
         val token = tokenDao.getToken()
-        datasource.reConnectStomp(
+        datasource.reConnectStompSocket(
             token?.token ?: "",
             token?.refreshToken ?: "",
         )
         delay(200)
         return datasource.subscribeRoom(chatRoomId)
-            .flowOn(dispatcher)
+//            .flowOn(dispatcher)
             .map {
                 it.toEventModel(userId)
             }

--- a/feature-main/chat-datail/src/main/java/com/seugi/chatdatail/ChatDetailScreen.kt
+++ b/feature-main/chat-datail/src/main/java/com/seugi/chatdatail/ChatDetailScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -254,9 +255,15 @@ internal fun ChatDetailScreen(
         )
     }
 
+    DisposableEffect(Unit) {
+        onDispose {
+            viewModel.socketClose()
+        }
+    }
+
     LifecycleStartEffect(key1 = Unit) {
         viewModel.collectStompLifecycle(chatRoomId, userId)
-        viewModel.channelReconnect(userId, chatRoomId)
+        viewModel.channelConnect(userId, chatRoomId)
         onStopOrDispose {
             viewModel.subscribeCancel()
         }

--- a/feature-main/chat-datail/src/main/java/com/seugi/chatdatail/ChatDetailViewModel.kt
+++ b/feature-main/chat-datail/src/main/java/com/seugi/chatdatail/ChatDetailViewModel.kt
@@ -604,12 +604,12 @@ class ChatDetailViewModel @Inject constructor(
         }
     }
 
-    private fun channelConnect(userId: Long) {
+    fun channelConnect(userId: Long, roomId: String? = null) {
         viewModelScope.launch {
             subscribeChat?.cancel()
             val job = viewModelScope.async {
                 messageRepository.subscribeRoom(
-                    chatRoomId = state.value.roomInfo?.id ?: "",
+                    chatRoomId = roomId ?: state.value.roomInfo?.id ?: "",
                     userId = userId,
                 ).collect {
                     it.collectMessage(userId)
@@ -626,6 +626,10 @@ class ChatDetailViewModel @Inject constructor(
         subscribeLifecycle = null
         subscribeChat?.cancel()
         subscribeChat = null
+    }
+
+    fun socketClose() = viewModelScope.launch {
+        messageRepository.closeSocket()
     }
 
     fun leftRoom(chatRoomId: String) {

--- a/feature-main/chat-datail/src/main/java/com/seugi/chatdatail/ChatDetailViewModel.kt
+++ b/feature-main/chat-datail/src/main/java/com/seugi/chatdatail/ChatDetailViewModel.kt
@@ -373,7 +373,7 @@ class ChatDetailViewModel @Inject constructor(
                             content = content,
                             mention = mention,
                         )
-                        channelReconnect(userId)
+                        channelConnect(userId)
                         return@launch
                     }
                     // 메세지가 보내고 MESSAGE_TIMEOUT 시간만큼 지났는데도 안보내지면 실패처리

--- a/network/core/src/main/java/com/seugi/network/core/SeugiUrl.kt
+++ b/network/core/src/main/java/com/seugi/network/core/SeugiUrl.kt
@@ -21,6 +21,7 @@ object SeugiUrl {
         const val SEND = "/pub/chat.message"
         const val GET_MESSAGE = "${BASE_URL}/message/search"
         const val EMOJI = "$MESSAGE/emoji"
+        const val ERRORS = "/user/queue/errors"
     }
 
     object PersonalChat {

--- a/network/message/src/main/java/com/seugi/network/message/MessageDataSource.kt
+++ b/network/message/src/main/java/com/seugi/network/message/MessageDataSource.kt
@@ -4,6 +4,7 @@ import com.seugi.network.core.response.BaseResponse
 import com.seugi.network.core.response.Response
 import com.seugi.network.message.response.MessageRoomEventResponse
 import com.seugi.network.message.response.message.MessageLoadResponse
+import com.seugi.network.message.response.stomp.MessageStompErrorResponse
 import com.seugi.network.message.response.stomp.MessageStompLifecycleResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDateTime
@@ -11,11 +12,15 @@ import kotlinx.datetime.LocalDateTime
 interface MessageDataSource {
     suspend fun subscribeRoom(chatRoomId: String): Flow<MessageRoomEventResponse>
 
+    suspend fun subscribeError(): Flow<MessageStompErrorResponse>
+
     suspend fun sendMessage(chatRoomId: String, message: String, messageUUID: String, type: String, mention: List<Long>): Boolean
 
-    suspend fun connectStomp(accessToken: String)
+    suspend fun connectStompSocket(accessToken: String)
 
-    suspend fun reConnectStomp(accessToken: String, refreshToken: String)
+    suspend fun reConnectStompSocket(accessToken: String, refreshToken: String)
+
+    suspend fun closeStompSocket()
 
     suspend fun getIsConnect(): Boolean
 

--- a/network/message/src/main/java/com/seugi/network/message/datasource/MessageDataSourceImpl.kt
+++ b/network/message/src/main/java/com/seugi/network/message/datasource/MessageDataSourceImpl.kt
@@ -52,7 +52,7 @@ class MessageDataSourceImpl @Inject constructor(
     }
 
     override suspend fun reConnectStompSocket(accessToken: String, refreshToken: String): Unit = coroutineScope {
-//        stompClient.disconnectCompletable().subscribe { }
+        stompClient.disconnectCompletable().subscribe { }
         connectStompSocket(accessToken)
     }
 

--- a/network/message/src/main/java/com/seugi/network/message/response/stomp/MessageStompErrorResponse.kt
+++ b/network/message/src/main/java/com/seugi/network/message/response/stomp/MessageStompErrorResponse.kt
@@ -4,5 +4,5 @@ data class MessageStompErrorResponse(
     val status: Int,
     val success: Boolean,
     val state: String,
-    val message: String
+    val message: String,
 )

--- a/network/message/src/main/java/com/seugi/network/message/response/stomp/MessageStompErrorResponse.kt
+++ b/network/message/src/main/java/com/seugi/network/message/response/stomp/MessageStompErrorResponse.kt
@@ -1,0 +1,8 @@
+package com.seugi.network.message.response.stomp
+
+data class MessageStompErrorResponse(
+    val status: Int,
+    val success: Boolean,
+    val state: String,
+    val message: String
+)


### PR DESCRIPTION
## 개요 (필수)

- 현재 서버에서 구독을 통해 제공하는 에러 예외처리는 현재 로직으로도 충분히 처리가 가능하다고 판단했습니다. 그래서 해당 기능을 추가하지 않았습니다.
- 소켓의 안정성을 높였습니다.

## 이슈 번호

- close #370 